### PR TITLE
add more methods, remove dft message

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,23 @@ assert(a !== b, `${a} !== ${b}`)
 ## API
 
 ### `assert(declaration, [message])`
+### `assert.ok(declaration, [message])`
 
 Assert that `declaration` is truthy otherwise throw `Error` with
-optional `message`, which defaults to `AssertionError`. If you want friendlier
-messages you can use template strings to show the assertion made like in the
-example above.
+optional `message`. If you want friendlier messages you can use template
+strings to show the assertion made like in the example above.
+
+### `assert.notOk(declaration, [message])`
+
+Assert that `declaration` is not truthy.
+
+### `assert.equal(a, b, [message])`
+
+Assert that `a` is loosely equal to `b`. Uses `==` for the comparison.
+
+### `assert.notEqual(a, b, [message])`
+
+Assert that `a` is loosely not equal to `b`. Uses `==` for the comparison.
 
 ## Why
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,22 @@
-module.exports = function (t, m) {
+assert.notEqual = notEqual
+assert.notOk = notOk
+assert.equal = equal
+assert.ok = assert
+
+module.exports = assert
+
+function equal (a, b, m) {
+  assert(a == b, m) // eslint-disable-line eqeqeq
+}
+
+function notEqual (a, b, m) {
+  assert(a != b, m) // eslint-disable-line eqeqeq
+}
+
+function notOk (t, m) {
+  assert(!t, m)
+}
+
+function assert (t, m) {
   if (!t) throw new Error(m || 'AssertionError')
 }


### PR DESCRIPTION
Wanted to write this module, but saw you'd already written it haha. This PR contains a few changes; most notably:

- added `.equal`, `.ok`, `.notEqual`, and `.notOk` methods
- removed the default message

The reasoning to add more methods is because those are the methods we use all throughout the choo codebase / ecosystem. I'm planning to write a browserify transform to dynamically replace them with this module, which should make for some really cool results.

The default message was removed because strings don't compress well, and if people are going to be including custom messages everywhere anyway it's just dead code anyway.

Hope this PR makes sense; thanks! :D